### PR TITLE
Stripe Connectオンボーディングフローの実装

### DIFF
--- a/src/app/api/auth/onboarding/route.ts
+++ b/src/app/api/auth/onboarding/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getUser } from "@/lib/supabase-server"
+import { db } from "@/lib/db"
+import { users } from "@/lib/db/schema"
+import { eq } from "drizzle-orm"
+import { stripe } from "@/lib/stripe"
+import { isValidEmail } from "@/lib/utils/validation"
+
+export async function POST(request: NextRequest) {
+  try {
+    // Get authenticated user
+    const supabaseUser = await getUser()
+    if (!supabaseUser) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const { name } = body
+
+    if (!name || typeof name !== "string" || name.trim().length === 0) {
+      return NextResponse.json({ message: "Name is required" }, { status: 400 })
+    }
+
+    const email = supabaseUser.email
+    if (!email || !isValidEmail(email)) {
+      return NextResponse.json({ message: "Invalid email" }, { status: 400 })
+    }
+
+    // Check if user already exists in database
+    const existingUser = await db.query.users.findFirst({
+      where: eq(users.email, email),
+    })
+
+    // If user already has Stripe account and completed onboarding, redirect to refresh
+    if (existingUser?.stripeAccountId && existingUser?.onboardingAt) {
+      return NextResponse.json({ message: "Onboarding already completed" }, { status: 400 })
+    }
+
+    let stripeAccountId = existingUser?.stripeAccountId
+
+    // Create Stripe Connect account if doesn't exist
+    if (!stripeAccountId) {
+      const account = await stripe.accounts.create({
+        type: "standard",
+        country: "JP",
+        email: email,
+        capabilities: {
+          card_payments: { requested: true },
+          transfers: { requested: true },
+        },
+      })
+      stripeAccountId = account.id
+    }
+
+    // Update or create user in database
+    if (existingUser) {
+      await db
+        .update(users)
+        .set({
+          name: name.trim(),
+          stripeAccountId,
+          updatedAt: new Date(),
+        })
+        .where(eq(users.id, existingUser.id))
+    } else {
+      await db.insert(users).values({
+        id: supabaseUser.id,
+        email,
+        name: name.trim(),
+        stripeAccountId,
+      })
+    }
+
+    // Get app URL
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL
+    const isProduction = process.env.NODE_ENV === "production"
+    if (isProduction && !baseUrl) {
+      console.error("NEXT_PUBLIC_APP_URL is not configured in production")
+      return NextResponse.json({ message: "Application URL not configured" }, { status: 500 })
+    }
+    const appUrl = baseUrl || "http://localhost:3000"
+
+    // Create account link for onboarding
+    const accountLink = await stripe.accountLinks.create({
+      account: stripeAccountId,
+      refresh_url: `${appUrl}/onboarding`,
+      return_url: `${appUrl}/dashboard`,
+      type: "account_onboarding",
+    })
+
+    return NextResponse.json({ url: accountLink.url })
+  } catch (error) {
+    console.error("Onboarding error:", error)
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
+  }
+}

--- a/src/app/api/stripe/connect/refresh/route.ts
+++ b/src/app/api/stripe/connect/refresh/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server"
+import { getUser } from "@/lib/supabase-server"
+import { db } from "@/lib/db"
+import { users } from "@/lib/db/schema"
+import { eq } from "drizzle-orm"
+import { stripe } from "@/lib/stripe"
+
+export async function GET() {
+  try {
+    // Get authenticated user
+    const supabaseUser = await getUser()
+    if (!supabaseUser) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+
+    // Get user from database
+    const user = await db.query.users.findFirst({
+      where: eq(users.email, supabaseUser.email!),
+    })
+
+    if (!user || !user.stripeAccountId) {
+      return NextResponse.json(
+        { message: "Stripe account not found. Please complete onboarding first." },
+        { status: 404 }
+      )
+    }
+
+    // Get app URL
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL
+    const isProduction = process.env.NODE_ENV === "production"
+    if (isProduction && !baseUrl) {
+      console.error("NEXT_PUBLIC_APP_URL is not configured in production")
+      return NextResponse.json({ message: "Application URL not configured" }, { status: 500 })
+    }
+    const appUrl = baseUrl || "http://localhost:3000"
+
+    // Create a new account link for the existing Stripe account
+    const accountLink = await stripe.accountLinks.create({
+      account: user.stripeAccountId,
+      refresh_url: `${appUrl}/onboarding`,
+      return_url: `${appUrl}/dashboard`,
+      type: "account_onboarding",
+    })
+
+    // Redirect to Stripe onboarding
+    return NextResponse.redirect(accountLink.url)
+  } catch (error) {
+    console.error("Refresh account link error:", error)
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
+  }
+}

--- a/src/app/api/stripe/connect/status/route.ts
+++ b/src/app/api/stripe/connect/status/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server"
+import { getUser } from "@/lib/supabase-server"
+import { db } from "@/lib/db"
+import { users } from "@/lib/db/schema"
+import { eq } from "drizzle-orm"
+import { stripe } from "@/lib/stripe"
+
+export async function GET() {
+  try {
+    // Get authenticated user
+    const supabaseUser = await getUser()
+    if (!supabaseUser) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 })
+    }
+
+    // Get user from database
+    const user = await db.query.users.findFirst({
+      where: eq(users.email, supabaseUser.email!),
+    })
+
+    if (!user || !user.stripeAccountId) {
+      return NextResponse.json(
+        {
+          completed: false,
+          hasStripeAccount: false,
+        },
+        { status: 200 }
+      )
+    }
+
+    // Check Stripe account status
+    const account = await stripe.accounts.retrieve(user.stripeAccountId)
+
+    // Check if account can accept payments (charges_enabled means fully onboarded)
+    const isFullyOnboarded = account.charges_enabled === true
+
+    // If fully onboarded but onboardingAt not set, update it
+    if (isFullyOnboarded && !user.onboardingAt) {
+      await db
+        .update(users)
+        .set({
+          onboardingAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(users.id, user.id))
+    }
+
+    return NextResponse.json({
+      completed: isFullyOnboarded,
+      hasStripeAccount: true,
+      onboardingAt: user.onboardingAt,
+    })
+  } catch (error) {
+    console.error("Check onboarding status error:", error)
+    return NextResponse.json({ message: "Internal server error" }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## 概要 / Overview
講師がStripe Connectアカウントを作成し、決済を受け取れるようにするオンボーディングフローを実装しました。

## 関連Issue / Related Issues
Resolves #7

## 変更内容 / Changes

### API実装
- **オンボーディングAPI** (`/api/auth/onboarding`)
  - Supabase認証によるユーザー検証
  - Stripe Standard Connectアカウントの作成（日本リージョン）
  - ユーザー情報のデータベース保存
  - Account Linkの生成とStripeオンボーディングへのリダイレクト

- **リフレッシュAPI** (`/api/stripe/connect/refresh`)
  - オンボーディング中断時の再開用リンク生成
  - 既存のStripe アカウントIDを使用して新しいAccount Linkを作成

- **ステータスチェックAPI** (`/api/stripe/connect/status`)
  - Stripeアカウントの`charges_enabled`フラグでオンボーディング完了を確認
  - 完了時に`onboardingAt`タイムスタンプを自動更新
  - オンボーディング状態をフロントエンドに返却

### 技術仕様
- **Stripe Connect**: Standard アカウントタイプ
- **リージョン**: 日本 (JP)
- **機能**: カード決済 + 送金機能
- **Account Links**: `account_onboarding`タイプ
- **リダイレクトURL**:
  - `refresh_url`: オンボーディングページ（中断時の再開用）
  - `return_url`: ダッシュボード（完了後の遷移先）

### セキュリティ
- Supabase認証必須
- メールアドレスのRFC 5322準拠バリデーション
- 環境別URL設定（本番環境では必須チェック）
- 適切なエラーハンドリングとロギング

## フロー / Flow

1. 講師がオンボーディングページで名前を入力
2. `/api/auth/onboarding`にPOSTリクエスト
3. Stripe Connectアカウントを作成（新規の場合）
4. ユーザー情報とStripe Account IDをデータベースに保存
5. Stripe Account Linkを生成
6. Stripeのオンボーディング画面にリダイレクト
7. 講師が必要情報を入力
8. 完了後、ダッシュボードにリダイレクト
9. ダッシュボードで`/api/stripe/connect/status`を呼び出し
10. オンボーディング完了を確認し、`onboardingAt`を更新

## テスト / Testing

### ローカルテスト手順
1. Supabaseで認証済みユーザーとしてログイン
2. `/onboarding`ページにアクセス
3. 名前を入力して「次へ（Stripe設定）」をクリック
4. Stripeのオンボーディング画面にリダイレクトされることを確認
5. テストモードで必要情報を入力
6. ダッシュボードに戻ることを確認
7. データベースで`stripeAccountId`と`onboardingAt`が設定されていることを確認

### 中断後の再開テスト
1. オンボーディング途中でブラウザを閉じる
2. 再度`/onboarding`ページにアクセス
3. `/api/stripe/connect/refresh`を呼び出してStripeページに戻る

## 備考 / Notes
- Stripe Connectアカウントは一度作成されると再利用される
- オンボーディング完了は`charges_enabled`フラグで判定
- 本番環境では講師がオンボーディングを完了しないと決済を受け取れない
- 開発環境では`NEXT_PUBLIC_APP_URL`のフォールバックとしてlocalhostを使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>